### PR TITLE
persistence: fix null store when using always

### DIFF
--- a/src/persistence.js
+++ b/src/persistence.js
@@ -34,6 +34,7 @@ export const storage = {
   },
 
   set entry ({name, winner}) {
+    if (!this._store) this._store = {};
     this._store[name] = winner
     this._save()
   }


### PR DESCRIPTION
`<split-test name="my_test" always="C" >`

Would throw `Cannot set property 'my_test' of null` when trying to `this._store[name] = winner;` since the store was never created.